### PR TITLE
File name fixed

### DIFF
--- a/lib/attachment_on_the_fly.rb
+++ b/lib/attachment_on_the_fly.rb
@@ -55,7 +55,7 @@ Paperclip::Attachment.class_eval do
       width = height
       prefix = "S_" + height.to_s + "_WIDTH_"
     elsif kind == "both"
-      prefix = "S_" + height.to_s + "_" + height.to_s + "_"
+      prefix = "S_" + height.to_s + "_" + width.to_s + "_"
     end
     
     path = self.path


### PR DESCRIPTION
When the height and width are specified, the new file is created as "S_HEIGHT_HEIGHT..." instead of "S_HEIGHT_WIDTH...". Just fixed that.

Thanks,
Roy
