### PR TITLE
S3 integration & refactoring

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -84,6 +84,16 @@ Attachment-on-the-fly refers to the following optional entries in Paperclip.opti
 
 Example: Paperclip.options[:whiny] = true
 
+== S3 integration
+
+S3 integration is tested with aws-sdk of version < 2.0. It is not guaranteed to work flawlessly with latter versions.
+
+Here is an overview of how it works:
+1. the desired-dimensioned image is looked up in S3 bucket (specified by your paperclip relation options)
+2. in case there is already an image ready, it simply passes url to user
+3. otherwise original file is downloaded from S3, converted to desired size and uploaded back to S3
+4. user receives image link (hosted at S3). next time anybody askes for the same image size, he'll get this link at step 2.
+
 ==Contributing
 
 If you find this gem useful, please post your comments, bugs, patches and

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ begin
     gemspec.description = "A Paperclip mix-in to allow auto-generation of resized images"
     gemspec.email = "jefferey.sutherland@gmail.com"
     gemspec.homepage = "http://github.com/drpentode/Attachment-on-the-Fly"
-    gemspec.authors = ["Jeff Sutherland", "Ben Ellis", "Blake Hyde"]
+    gemspec.authors = ["Jeff Sutherland", "Ben Ellis", "Blake Hyde", 'twonegatives']
     gemspec.add_dependency "paperclip"
   end
 rescue LoadError

--- a/attachment_on_the_fly.gemspec
+++ b/attachment_on_the_fly.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version = "0.1.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Jeff Sutherland", "Ben Ellis", "Blake Hyde"]
+  s.authors = ["Jeff Sutherland", "Ben Ellis", "Blake Hyde", "twonegatives"]
   s.date = "2013-12-05"
   s.description = "A Paperclip mix-in to allow auto-generation of resized images"
   s.email = "jefferey.sutherland@gmail.com"

--- a/lib/attachment_on_the_fly.rb
+++ b/lib/attachment_on_the_fly.rb
@@ -48,70 +48,61 @@ Paperclip::Attachment.class_eval do
     return image_name
   end
 
+  def convert_command_path
+    if Paperclip.options[:command_path]
+      Paperclip.options[:command_path] + "/"
+    else
+      ""
+    end
+  end
+
+  def get_url_path
+    url_arr = self.url.split("/")
+    url_file_name = url_arr.pop
+    url_path = url_arr.join("/")
+  end
+
   def generate_image(kind, height = 0, width = 0, parameters = {})
-    convert_command_path = (Paperclip.options[:command_path] ? Paperclip.options[:command_path] + "/" : "")
     parameters.symbolize_keys!
     [:extension, :quality].each do |opt|
       parameters.reverse_merge!({opt => Paperclip.options[opt]}) if Paperclip.options[opt]
     end
-    quality = parameters[:quality] ||= 100
+    quality = parameters[:quality] || 100
     parameters.delete :quality
 
-    prefix = ""
+    prefix =
+      case kind 
+      when "height"
+        "S_" + height.to_s + "_HEIGHT_"
+      when "width"
+        width = height
+        "S_" + height.to_s + "_WIDTH_"
+      when "both"
+        "S_" + width.to_s + "_" + height.to_s + "_"
+      end
 
-    if kind == "height"
-      prefix = "S_" + height.to_s + "_HEIGHT_"
-    elsif kind == "width"
-      width = height
-      prefix = "S_" + height.to_s + "_WIDTH_"
-    elsif kind == "both"
-      prefix = "S_" + width.to_s + "_" + height.to_s + "_"
-    end
     presuffix = parameters.map{|k,v| "#{k}_#{v}" }.join('___') + "_q_#{quality}_"
     prefix = "#{prefix}#{presuffix}_"
     prefix = "#{prefix}#{Paperclip.options[:version_prefix]}_" if Paperclip.options[:version_prefix]
 
-    path = self.path
-    url = self.url
+    path = File.dirname(self.path)
+    path = path + '/' unless path.end_with?('/')
 
-    path_arr = path.split("/")
-    file_name = path_arr.pop
-    path = path_arr.join("/")
+    original_extension  = File.extname(self.path).delete('.')
+    base_name           = File.basename(self.path, File.extname(self.path))
+    extension           = parameters[:extension] || original_extension
 
-    base_arr = file_name.split('.');
-    original_extension = extension = base_arr.pop
-    base_name = base_arr.join('.')
-    extension = parameters[:extension] || extension
-    parameters.delete :extension
+    url_path = get_url_path
 
-    url_arr = url.split("/")
-    url_file_name = url_arr.pop
-    url_path = url_arr.join("/")
-
-    original = path + "/" + self.original_filename
-    newfilename = path + "/" + prefix + base_name +  '.' + extension
-    fallback_newfilename = path + "/" + prefix + base_name +  '.' + original_extension
-    new_path = url_path + "/" + prefix + base_name + '.' + extension
-    fallback_new_path = url_path + "/" + prefix + base_name + '.' + original_extension
+    original              = path + self.original_filename
+    newfilename           = path + prefix + base_name +  '.' + extension
+    fallback_newfilename  = path + prefix + base_name +  '.' + original_extension
+    new_path              = url_path + "/" + prefix + base_name + '.' + extension
+    fallback_new_path     = url_path + "/" + prefix + base_name + '.' + original_extension
+    
     return new_path if File.exist?(newfilename)
+    return missing_path(original, new_path) unless File.exist?(original)
 
-    if !File.exist?(original)
-      if Paperclip.options[:whiny]
-        raise AttachmentOnTheFlyError.new("Original asset could not be read from disk at #{original}")
-      else
-        Paperclip.log("Original asset could not be read from disk at #{original}")
-        if Paperclip.options[:missing_image_path]
-          return Paperclip.options[:missing_image_path]
-        else
-          Paperclip.log("Please configure Paperclip.options[:missing_image_path] to prevent return of broken image path")
-          return new_path
-        end
-      end
-    end
-
-    command = ""
-
-    options_for_extension = ""
     if original_extension != extension && has_alpha?(original)
       # Converting extension with alpha channel is problematic.
       # Fall back to original extension.
@@ -125,20 +116,36 @@ Paperclip::Attachment.class_eval do
 
     base_command = "#{convert_command_path}convert #{colorspace_opt} -strip -geometry"
 
-    if kind == "height"
-      # resize_image infilename, outfilename , 0, height
-      command = "#{base_command} x#{height} -quality #{quality} -sharpen 1 '#{original}' '#{newfilename}' 2>&1 > /dev/null"
-    elsif kind == "width"
-      # resize_image infilename, outfilename, width
-      command = "#{base_command} #{width} -quality #{quality} -sharpen 1 '#{original}' '#{newfilename}' 2>&1 > /dev/null"
-    elsif kind == "both"
-      # resize_image infilename, outfilename, height, width
-      command = "#{base_command} #{width}x#{height} -quality #{quality} -sharpen 1 '#{original}' '#{newfilename}' 2>&1 > /dev/null"
-    end
+    command =
+      case kind
+      when "height"
+        # resize_image infilename, outfilename , 0, height
+        "#{base_command} x#{height} -quality #{quality} -sharpen 1 '#{original}' '#{newfilename}' 2>&1 > /dev/null"
+      when "width"
+        # resize_image infilename, outfilename, width
+        "#{base_command} #{width} -quality #{quality} -sharpen 1 '#{original}' '#{newfilename}' 2>&1 > /dev/null"
+      when "both"
+        # resize_image infilename, outfilename, height, width
+        "#{base_command} #{width}x#{height} -quality #{quality} -sharpen 1 '#{original}' '#{newfilename}' 2>&1 > /dev/null"
+      end
 
     convert_command command
 
     return new_path
+  end
+
+  def missing_path original, new_path
+    if Paperclip.options[:whiny]
+      raise AttachmentOnTheFlyError.new("Original asset could not be read from disk at #{original}")
+    else
+      Paperclip.log("Original asset could not be read from disk at #{original}")
+      if Paperclip.options[:missing_image_path]
+        return Paperclip.options[:missing_image_path]
+      else
+        Paperclip.log("Please configure Paperclip.options[:missing_image_path] to prevent return of broken image path")
+        return new_path
+      end
+    end
   end
 
   def convert_command command


### PR DESCRIPTION
Hey there. Hope this repository is not abandoned.
I've noticed that Attachment-on-the-Fly does not support storages other than `filesystem`. So I decided to add support for resizing images located at Amazon S3.
The code seemed a bit procedural, so I've also changed a couple of things to make it look a little prettier.
